### PR TITLE
Added installation of karma-cli package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "example of recursive tree in angular",
   "main": "app/index.html",
   "scripts": {
-    "postinstall": "bower install",
-    "test": "./node_modules/karma/bin/karma start"
+    "postinstall": "bower install & npm install -g karma-cli",
+    "test": "karma start"
   },
   "author": "Pavel Nikolajev",
   "repository": {


### PR DESCRIPTION
Hi Pavel,

For some reason on Windows the command `./node_modules/karma/bin/karma start` does not work. This issue can be resolved by installing `karma-cli` package so I added it into postinstall.
